### PR TITLE
chorny/Win32-TieRegistry#1 on registry test

### DIFF
--- a/t/10-registry.t
+++ b/t/10-registry.t
@@ -22,6 +22,7 @@ BEGIN { use_ok('Win32::Setupsup') }
 
 use Win32::TieRegistry ( Delimiter=>"/", ArrayValues=>0 );
 
+$Registry = $Registry->Open('', {Access => KEY_READ} ); # RT#102385
 my $winReg = $Registry->{'LMachine/Software/Microsoft/Windows/CurrentVersion/'};
 
 my $value;


### PR DESCRIPTION
As non-administrator, registry must be explicitly opened as per referenced issue on Win32::TieRegistry